### PR TITLE
Remove unuseful lodash import

### DIFF
--- a/src/createReducerAsync.js
+++ b/src/createReducerAsync.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import {createReducer} from 'redux-act';
 
 const defaultsState = {


### PR DESCRIPTION
This import is not only pointless but also pollutes the global space with a new `window._`. It could affect any app relying on an another version of lodash or underscore.