### PR TITLE
chore(lodash): remove lodash.defaultdeep

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "lodash.defaultsdeep": "4.6",
+    "object-assign": "^4.1.1",
     "redux-act": "1.1.0"
   }
 }

--- a/src/createActionAsync.js
+++ b/src/createActionAsync.js
@@ -1,5 +1,5 @@
 import {createAction} from 'redux-act'
-import _defaults from 'lodash.defaultsdeep';
+import objectAssign from 'object-assign';
 
 export const ASYNC_META = {
   REQUEST: "REQUEST",
@@ -29,7 +29,12 @@ const defaultOption = {
 
 export default function createActionAsync(description, api, options = defaultOption) {
 
-  _defaults(options, defaultOption);
+  options = {
+    noRethrow: options.noRethrow !== undefined ? options.noRethrow : defaultOption.noRethrow,
+    request: objectAssign({}, defaultOption.request, options.request),
+    ok: objectAssign({}, defaultOption.ok, options.ok),
+    error: objectAssign({}, defaultOption.error, options.error)
+  };
 
   let actions = {
     request: createAction(`${description}_${ASYNC_META.REQUEST}`, options.request.payloadReducer, options.request.metaReducer),
@@ -66,7 +71,7 @@ export default function createActionAsync(description, api, options = defaultOpt
     }
   }
 
-  Object.assign(actionAsync, actions);
+  objectAssign(actionAsync, actions);
   actionAsync.options = options;
   return actionAsync;
 }


### PR DESCRIPTION
switch from lodash.defaultdeep to object-assign

-----

I'm using this package on my project (Great one btw :smile: )

I've notice one of its dependency (lodash.defaultdeep) is using a lot of space, so to reduce the bundle size I replaced it with a lighter package: https://github.com/sindresorhus/object-assign
It follow `Object.assign` specs so it can be replace once IE11 is out of the market: http://kangax.github.io/compat-table/es6/#test-Object_static_methods_Object.assign