### PR TITLE
chore(deps): loosen up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
   },
   "dependencies": {
     "lodash.defaultsdeep": "4.6",
-    "redux-act": "1.1.0"
+    "redux-act": "^1.1.0"
   }
 }


### PR DESCRIPTION
When I use `webpack`, `react-act` is bundles twice (`v1.1.0` and `v1.1.1`)

This just allow to use the same version